### PR TITLE
Fix bug when zipcode is not found

### DIFF
--- a/lib/zip-codes.rb
+++ b/lib/zip-codes.rb
@@ -36,7 +36,7 @@ module ZipCodes
       end
     end
 
-    @cache[country][country][zip_code] = nil
+    @cache[country][zip_code] = nil
   end
 
   def self.parse_entry(entry)


### PR DESCRIPTION
[Shortcut 8536](https://app.shortcut.com/rinsed/story/8536) Nil pointer exceptions like [this](https://rinsed.sentry.io/issues/4322016530/?environment=production&project=5194286) are happening when a zipcode is not found due to invalid indexing into the cache hash. 

Once this is fixed, I'm going to update the two spots in the Sonny's checkout and payment update code to handle a return value of `nil` and update the web Gemfile to a new commit hash for this gem. 