### PR TITLE
Loosen activesupport version requirement to allow Rails 7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     zip-codes (0.3.0)
-      activesupport (>= 6.0.0, < 7.1)
+      activesupport (>= 6.0.0)
       fastcsv (~> 0.0.6)
 
 GEM

--- a/zip-codes.gemspec
+++ b/zip-codes.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir['lib/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 6.0.0', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 6.0.0'
   spec.add_dependency 'fastcsv', '~> 0.0.6'
 end


### PR DESCRIPTION
I tested and it seems to work just fine with Rails 7.1. There's very little Ruby code and very little dependence on ActiveSupport, I think we can just open it up to future versions of Rails.

Also sometime we should think about replacing this gem...the csv of zip codes will become more outdated over time.