### PR TITLE
Do not allow the zip_codes gem to send nil into ActiveSupport::TimeZone.new

### DIFF
--- a/lib/zip-codes.rb
+++ b/lib/zip-codes.rb
@@ -40,11 +40,12 @@ module ZipCodes
   end
 
   def self.parse_entry(entry)
+    time_zone = ActiveSupport::TimeZone.new(entry[4]) if entry[4]
     {
       city: entry[3],
       state_code: entry[1],
       state_name: entry[2],
-      time_zone: ActiveSupport::TimeZone.new(entry[4])
+      time_zone:
     }
   end
 end


### PR DESCRIPTION
[Shortcut 39744](https://app.shortcut.com/rinsed/story/39744) - See this Rollbar item: https://app.rollbar.com/a/rinsed/fix/item/Web/5731

This error happens when looking up a zipcode and the [underlying CSV zipcode data](https://github.com/rinsed-org/zip-codes/blob/master/lib/data/US.csv) has a missing timezone element for the relevant row.

This can be solved by either fixing the underlying data (estimating the timezone for military bases and filling in several missing timezones for KY and SD) or by not trying to obtain a timezone if the field is missing. I chose the latter because we're not using the timezone for anything at this point and I'd rather not make the process of updating the zipcode data more complex than it needs to be.

This was tested manually via `irb` (zip code 55122 has a timezone while 41728 does not):

> irb(main):002> ZipCodes.lookup("US", "55122")
=> 
{:city=>"Saint Paul",
 :state_code=>"MN",
 :state_name=>"Minnesota",
 :time_zone=>#<ActiveSupport::TimeZone:0x000000012025a820 @name="America/Chicago", @tzinfo=#<TZInfo::DataTimezone: America/Chicago>, @utc_offset=nil>}

> irb(main):003> ZipCodes.lookup("US", "41728")
=> {:city=>"Cinda", :state_code=>"KY", :state_name=>"Kentucky", :time_zone=>nil}

