### PR TITLE
Fix zip codes caching

### DIFF
--- a/lib/zip-codes.rb
+++ b/lib/zip-codes.rb
@@ -20,7 +20,6 @@ module ZipCodes
     return parse_entry(val) if val
 
     @cache[country] ||= {}
-    @cache[country][zip_code] ||= {}
 
     db = File.join(DB_DIR, "#{country}.csv")
 


### PR DESCRIPTION
The issue happens when there is more than one call to `ZipCodes.lookup("US", "ANY_ZIP_CODE")` with the same zip code at the same time.

When the first request comes, on line 23, it caches the empty hash for a zip code and proceeds to read the CSV file to find a match. If the first call is still reading the CSV file and the next call happens, it just returns the parsed empty hash (rusults in all the hash values to be `nil`s) on line 20 since `{}` evaluates to true.

The change is to cache a non-falsy value only when there is a match.

Purchase order HTTP request examples (submitted milliseconds one after another). One of the requests got `city` and `state` as `nil`s while another correct values, even though the `ZipCodes.lookup` was called with the same zip codes:
https://splash.app.rinsed.co/admin/http_requests/paCSpGBd8aKD6u1K
https://splash.app.rinsed.co/admin/http_requests/z6EAfBuuJf1KL2fh

https://soapyshark.app.rinsed.co/admin/http_requests/wa159srW3gwWp1Hu
https://soapyshark.app.rinsed.co/admin/http_requests/8nXqnjBP6qChbAR7