### PR TITLE
chore(deps): bump activesupport and rexml to patch CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,23 +8,38 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
+    drb (2.2.3)
     fastcsv (0.0.6)
-    i18n (1.12.0)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    minitest (5.16.2)
+    logger (1.7.0)
+    minitest (5.26.1)
+    mutex_m (0.3.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     regexp_parser (2.3.0)
-    rexml (3.2.5)
+    rexml (3.4.4)
     rubocop (1.27.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -37,7 +52,8 @@ GEM
     rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    tzinfo (2.0.4)
+    securerandom (0.3.2)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
 


### PR DESCRIPTION
## Summary

Bumps `activesupport` and `rexml` to close 12 Dependabot alerts (1 high, 10 medium, 1 low).

| Gem | Before | After |
|-----|--------|-------|
| activesupport | 7.0.3.1 | 7.1.6 |
| rexml | 3.2.5 | 3.4.4 |
