### PR TITLE
chore(deps): bump activesupport to patched 7.2+ line

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,19 +8,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.6)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
-      mutex_m
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
-      tzinfo (~> 2.0)
+      tzinfo (~> 2.0, >= 2.0.5)
     ast (2.4.2)
     base64 (0.3.0)
     benchmark (0.5.0)
@@ -32,8 +31,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     logger (1.7.0)
-    minitest (5.26.1)
-    mutex_m (0.3.0)
+    minitest (5.27.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -52,7 +50,7 @@ GEM
     rubocop-ast (1.17.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    securerandom (0.3.2)
+    securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -65,4 +63,4 @@ DEPENDENCIES
   zip-codes!
 
 BUNDLED WITH
-   2.3.4
+   2.5.19


### PR DESCRIPTION
## Summary
- Bumps `activesupport` from 7.1.6 to 7.2.3.1 (minor train bump within gemspec `>= 6.0.0`)
- Closes Dependabot alerts #10 (SafeBuffer XSS), #11 (ReDoS), #12 (DoS)
- Transitive changes: `mutex_m` dropped, `minitest` 5.26.1->5.27.0, `securerandom` 0.3.2->0.4.1

## Note
Required resolving with Ruby >= 3.1 since activesupport 7.2+ has `required_ruby_version >= 3.1.0`. The gemspec has no Ruby version constraint so this is fine for consumers.